### PR TITLE
Fixes regarding previous 'no-express' update

### DIFF
--- a/assets/403.html
+++ b/assets/403.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>403 | Forbidden</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700&display=swap');
+        body {
+            margin: 0;
+            overflow: hidden;
+            background-color: #222231;
+            filter: blur(0.4px);
+        }
+        div {
+            font-size: 8.9vmin;
+            font-family: 'M PLUS Rounded 1c', sans-serif;
+            width: 70vmin;
+            text-align: center;
+            margin: 50vh 50vw;
+            transform: translate(-50%, -50%);
+            color: #fff;
+            text-shadow: 5px 4px 3px #000;
+        }
+        span {
+            color: #f6b411;
+        }
+    </style>
+</head>
+<body>
+    <div><span>403</span> | Forbidden</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
 	"dependencies": {
 		"accepts": "^1.3.8",
 		"etag": "^1.8.1",
-		"express": "^4.18.2",
-		"mime": "^1.6.0",
 		"mime-db": "^1.53.0",
 		"open": "^8.4.0",
 		"yargs": "^17.6.2"
@@ -27,7 +25,6 @@
 	"devDependencies": {
 		"@types/accepts": "^1.3.7",
 		"@types/etag": "^1.8.3",
-		"@types/express": "^4.17.21",
 		"@types/mime-db": "^1.43.5",
 		"@types/node": "^20.12.7",
 		"@types/yargs": "^17.0.32"
@@ -37,6 +34,10 @@
 		"LICENSE",
 		"index.js",
 		"index.d.ts",
+		"mime.js",
+		"mime.d.ts",
+		"static.js",
+		"static.d.ts",
 		"assets"
 	],
 	"keywords": [

--- a/src/static.ts
+++ b/src/static.ts
@@ -98,7 +98,10 @@ export default (root = './', options?: StaticOptions): StaticRequestHandler => {
 			throw new StaticError(404, 'not found')
 		} catch (err) {
 			if (err instanceof StaticError) {
-				if (FALLTHROUGH) next()
+				if (FALLTHROUGH) {
+					res.status(err.code)
+					next()
+				}
 				else next(err)
 			}
 			else throw err


### PR DESCRIPTION
Changelog:

* Fixed dotfiles handling

* Removed `mime`, `express`, `@types/express` dependencies from package.json

* Added `403.html` page

* Added new function for 403 response

* Added new yargs argument `--forbidden-page` for providing custom 403 page

* Fixed bugs involving redirects

* Changed epilogue to make it more clear